### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laminas/laminas-mvc-plugin-identity": "^1.2",
         "laminas/laminas-mvc-plugin-prg": "^1.3"
     },
-    "replace": {
-        "zendframework/zend-mvc-plugins": "^1.0.1"
+    "conflict": {
+        "zendframework/zend-mvc-plugins": "*"
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
